### PR TITLE
[bugfix] discriminator flatten mixing outputs within batch samples

### DIFF
--- a/pg_modules/discriminator.py
+++ b/pg_modules/discriminator.py
@@ -141,9 +141,9 @@ class MultiScaleD(nn.Module):
     def forward(self, features, c):
         all_logits = []
         for k, disc in self.mini_discs.items():
-            all_logits.append(disc(features[k], c).flatten())
+            all_logits.append(disc(features[k], c).view(features[k].size(0), -1))
 
-        all_logits = torch.cat(all_logits).reshape(features['0'].size(0), -1)
+        all_logits = torch.cat(all_logits, dim=1)
         return all_logits
 
 


### PR DESCRIPTION
Since outputs for each discriminators were first globally flattened, then concatenated and then reshaped to (bs,-1), the output scores for each sample within the mini batch were mixed. This fixes it.
// It didn't cause any issues with training since the scores are averaged for the loss anyway, but for debugging/analyzing/regularization it should be fixed