### PR TITLE
Unload checkpoint pickle after use

### DIFF
--- a/training/training_loop.py
+++ b/training/training_loop.py
@@ -181,6 +181,8 @@ def training_loop(
             __PL_MEAN__ = resume_data['progress'].get('pl_mean', torch.zeros([])).to(device)
             best_fid = resume_data['progress']['best_fid']       # only needed for rank == 0
 
+        del resume_data
+
     # Print network summary tables.
     if rank == 0:
         z = torch.empty([batch_gpu, G.z_dim], device=device)


### PR DESCRIPTION
Checkpoint pickle gets loaded, but never unloaded, causing an OOM error for runs that supposed to fit.

Using settings: `python train.py --outdir=./training-runs/ --cfg=fastgan --data=pokemon256.zip --gpus=1 --batch=8 --mirror=1 --snap=10 --batch-gpu=8 --kimg=10000 --metrics=None` I was able run training but not resume it while using a single 8GB GPU, all because the checkpoint pickle was wasting over 1GB of memory.